### PR TITLE
fix(ContextMenu): pass Menu as a function not component

### DIFF
--- a/shared/components/spotify_card.tsx
+++ b/shared/components/spotify_card.tsx
@@ -62,7 +62,7 @@ function SpotifyCard(props: SpotifyCardProps): React.ReactElement<HTMLDivElement
             : {};
 
     return (
-        <ContextMenu menu={<Menu />} trigger="right-click">
+        <ContextMenu menu={Menu()} trigger="right-click">
             <Card
                 featureIdentifier={type}
                 headerText={header}


### PR DESCRIPTION
This should fix passing props when right-clicking inside Custom App