### PR TITLE
fix(card): pass proper props to `CardImage` - fixes #87

### DIFF
--- a/shared/components/spotify_card.tsx
+++ b/shared/components/spotify_card.tsx
@@ -72,14 +72,8 @@ function SpotifyCard(props: SpotifyCardProps): React.ReactElement<HTMLDivElement
                 headerText={header}
                 renderCardImage={() => (
                     <CardImage
-                        images={[
-                            {
-                                height: 640,
-                                url: imageUrl,
-                                width: 640,
-                            },
-                        ]}
-                        isCircular={type === "artist"}
+                        src={imageUrl}
+                        size={640}
                     />
                 )}
                 renderSubHeaderContent={() => (


### PR DESCRIPTION
The current CardImage on V2 uses src and size props and doesn't have isCircular.

Will need to be reverted when V3 drops.