### PR TITLE
[feat(stats)]: Add auto-install for Windows using PowerShell

### DIFF
--- a/stats/README.md
+++ b/stats/README.md
@@ -50,6 +50,13 @@
 ```sh
 sh <(curl -s https://raw.githubusercontent.com/harbassan/spicetify-apps/main/stats/install.sh)
 ```
+
+### Automatic Installation (Windows, Powershell)
+
+```ps1
+iwr -useb "https://raw.githubusercontent.com/harbassan/spicetify-apps/main/stats/install.ps1" | iex
+```
+
 ### Manual Installation
 
 Download the zip file in the [latest release](https://github.com/harbassan/spicetify-apps/releases?q=stats&expanded=true), rename the unzipped folder to `stats`, then place that folder into your `CustomApps` folder in the `spicetify` directory and you're all done. If everything's correct, the structure should be similar to this:

--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -1,0 +1,40 @@
+# Define variables
+$customAppsDir = "$env:USERPROFILE\.config\spicetify\CustomApps"
+$statsAppDir = "$customAppsDir\stats"
+$repo = "harbassan/spicetify-apps"
+$zipFile = "$env:TEMP\spicetify-stats.zip"
+$tempDir = "$env:TEMP\spicetify-stats"
+
+# Create CustomApps directory if it doesn't exist
+If (!(Test-Path -Path $customAppsDir)) {
+  New-Item -ItemType Directory -Path $customAppsDir
+}
+
+# Get the latest release download URL
+$latestReleaseUrl = (Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest").assets.browser_download_url
+
+# Download the zip file
+Invoke-WebRequest -Uri $latestReleaseUrl -OutFile $zipFile
+
+# Unzip the file
+Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force
+
+# Move the unzipped folder to the correct location
+if (Test-Path -Path "$statsAppDir\*")
+{
+  Remove-Item -Path "$statsAppDir\*" -Recurse -Force
+  Write-Host "warning " -ForegroundColor DarkYellow -NoNewline
+  Write-Host "`"$statsAppDir`" Pre-existing file/s were found and deleted."
+}
+
+Move-Item -Path "$tempDir\*" -Destination $statsAppDir -Force
+
+# Apply Spicetify configuration
+spicetify config custom_apps stats
+spicetify apply
+
+# Clean up
+Remove-Item -Path $zipFile, $tempDir -Recurse -Force
+
+Write-Host "success " -ForegroundColor DarkGreen -NoNewline
+Write-Host "Installation complete. Enjoy your new stats app!"


### PR DESCRIPTION
### Description
Adds an auto-install feature for Windows using PowerShell. It's more or less a 1-to-1 translation of `install.sh`.

### Changes
- Created a PowerShell script for auto-installation.
- Updated documentation.

### Testing
Tested on Windows 11 Version 23H2 but used `iwr -useb "file:///<my directory>/spicetify-apps/stats/install.ps1" | iex` instead of `iwr -useb "https://raw.githubusercontent.com/harbassan/spicetify-apps/main/stats/install.ps1" | iex`.

### Checklist
- [x] I have added necessary documentation.
- [ ] I have tested my changes thoroughly.
