### PR TITLE
fix(stats): fix windows directory for auto-install

### DIFF
--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -40,4 +40,3 @@ Remove-Item -Path $zipFile, $tempDir -Recurse -Force
 
 Write-Host "success " -ForegroundColor DarkGreen -NoNewline
 Write-Host "Installation complete. Enjoy your new stats app!"
-#>

--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -1,5 +1,5 @@
 # Define variables
-$customAppsDir = "$env:USERPROFILE\AppData\Roaming\spicetify\CustomApps"
+$customAppsDir = "$env:APPDATA\Roaming\spicetify\CustomApps"
 $statsAppDir = "$customAppsDir\stats"
 $repo = "harbassan/spicetify-apps"
 $zipFile = "$env:TEMP\spicetify-stats.zip"

--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -1,5 +1,5 @@
 # Define variables
-$customAppsDir = "$env:USERPROFILE\.config\spicetify\CustomApps"
+$customAppsDir = "$env:USERPROFILE\AppData\Roaming\spicetify\CustomApps"
 $statsAppDir = "$customAppsDir\stats"
 $repo = "harbassan/spicetify-apps"
 $zipFile = "$env:TEMP\spicetify-stats.zip"

--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -10,18 +10,20 @@ If (!(Test-Path -Path $customAppsDir)) {
   New-Item -ItemType Directory -Path $customAppsDir
 }
 
-# Get the latest release download URL
-$latestReleaseUrl = (Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest").assets.browser_download_url
+# Get the latest STATS release download URL
+$latestRelease = (Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases") | Where-Object {
+      $_.tag_name -match "stats-v[0-9]+\.[0-9]+\.[0-9]+"
+    } | Select-Object -First 1;
+$latestReleaseDownloadUrl = (Invoke-RestMethod -Uri $latestRelease.url).assets[0].browser_download_url
 
 # Download the zip file
-Invoke-WebRequest -Uri $latestReleaseUrl -OutFile $zipFile
+Invoke-WebRequest -Uri $latestReleaseDownloadUrl -OutFile $zipFile
 
 # Unzip the file
 Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force
 
 # Move the unzipped folder to the correct location
-if (Test-Path -Path "$statsAppDir\*")
-{
+if (Test-Path -Path "$statsAppDir\*") {
   Remove-Item -Path "$statsAppDir\*" -Recurse -Force
   Write-Host "warning " -ForegroundColor DarkYellow -NoNewline
   Write-Host "`"$statsAppDir`" Pre-existing file/s were found and deleted."
@@ -38,3 +40,4 @@ Remove-Item -Path $zipFile, $tempDir -Recurse -Force
 
 Write-Host "success " -ForegroundColor DarkGreen -NoNewline
 Write-Host "Installation complete. Enjoy your new stats app!"
+#>

--- a/stats/install.ps1
+++ b/stats/install.ps1
@@ -1,5 +1,5 @@
 # Define variables
-$customAppsDir = "$env:APPDATA\Roaming\spicetify\CustomApps"
+$customAppsDir = "$env:APPDATA\spicetify\CustomApps"
 $statsAppDir = "$customAppsDir\stats"
 $repo = "harbassan/spicetify-apps"
 $zipFile = "$env:TEMP\spicetify-stats.zip"


### PR DESCRIPTION
Fixes #157 (You may close that now).

Should point to the correct directory now according to the [docs](https://spicetify.app/docs/advanced-usage/custom-apps).