### PR TITLE
fix(stats): use unicode explicit icon

### DIFF
--- a/stats/src/components/track_row.tsx
+++ b/stats/src/components/track_row.tsx
@@ -16,10 +16,13 @@ const ArtistLink = ({ name, uri, index, length }: { name: string; uri: string; i
 const ExplicitBadge = React.memo(() => {
 	return (
 		<>
-			<span className="TypeElement-ballad-textSubdued-type main-trackList-rowBadges" data-encore-id="type">
-				<span aria-label="Explicit" className="main-tag-container" title="Explicit">
-					E
-				</span>
+			<span
+				className="TypeElement-ballad-textSubdued-type main-trackList-rowBadges"
+				data-encore-id="type"
+				aria-label="Explicit"
+				title="Explicit"
+			>
+				🅴
 			</span>
 		</>
 	);

--- a/stats/src/styles/app.scss
+++ b/stats/src/styles/app.scss
@@ -114,6 +114,9 @@
     .main-trackList-rowPlayPauseIcon {
         fill: currentColor;
     }
+    .main-trackList-rowBadges {
+        color: var(--spice-text);
+    }
 
     .extend-button {
         background-color: transparent;


### PR DESCRIPTION
Use the [NEGATIVE SQUARED LATIN CAPITAL LETTER E](https://www.fileformat.info/info/unicode/char/1f174/index.htm) unicode character for the explicit icon ("🅴"), instead of just a plaintext character ("E") styled by the `main-tag-container` class.

The goal is to fix an issue where the explicit icon is just an empty box, depending on the theme and the background color that the `main-tag-container` class has. For instance, using the [Sleek theme](https://github.com/spicetify/spicetify-themes/tree/master/Sleek), the explicit icon is just a solid white box:

<img width="747" alt="Screenshot 2024-12-26 at 1 58 34 PM" src="https://github.com/user-attachments/assets/8d1dcb60-444b-40d7-866b-da144998a2de" />

Switching to the unicode character, removing the `main-tag-container` class, and setting the `color` to the `spice-text` CSS variable seems to produce much more consistent results across various themes. It has the added advantage of being closer in appearance to the actual Spotify explicit icon. For instance, using the same theme:

<img width="774" alt="Screenshot 2024-12-26 at 2 02 54 PM" src="https://github.com/user-attachments/assets/43c97eae-2ed5-4c24-9c0c-846b03ef5b04" />